### PR TITLE
Update for Factorio 1.1.

### DIFF
--- a/src/info.json
+++ b/src/info.json
@@ -5,7 +5,7 @@
     "author": "<NO_NAME> & DeTNTonator",
     "contact": "",
     "homepage": "",
-    "factorio_version": "0.18",
+    "factorio_version": "1.1",
     "dependencies": [
     		"base >= 0.18.0",
     		"? angelsinfiniteores",

--- a/src/prototypes/ores-retexture.lua
+++ b/src/prototypes/ores-retexture.lua
@@ -30,12 +30,19 @@ local function changeOreTextures(oreNameKey, oreName, doShadows, tint)
 			local pics = oreItem.pictures
 			if pics then
 				for i, _ in ipairs(pics) do
-					pics[i].filename = getNewTexturePath(pics[i].filename)
+					-- Uranium ore uses layers, the rest don't.
+					if pics[i].layers then
+						for l, _ in ipairs(pics[i].layers) do
+							pics[i].layers[l].filename = getNewTexturePath(pics[i].layers[l].filename)
+						end
+					else
+						pics[i].filename = getNewTexturePath(pics[i].filename)
+					end
 				end
 			end
 		end
 	end
-	
+
 	if patchesEnabled(oreSettings[oreNameKey]) then
 		local oreResource = data.raw.resource[oreName .. "-ore"]
 		if oreResource then
@@ -62,7 +69,7 @@ local function changeOreTextures(oreNameKey, oreName, doShadows, tint)
 				end
 			end
 		end
-		
+
 		local oreParticle = data.raw['optimized-particle'][oreName .. "-ore-particle"]
 		if oreParticle then
 			for k,picture in pairs(oreParticle.pictures) do
@@ -95,6 +102,7 @@ if itemsEnabled(oreSettings["uranium"]) then
 	local uraniumProcessingTech = data.raw.technology["uranium-processing"]
 	if uraniumProcessingTech then
 		uraniumProcessingTech.icon = getNewTexturePath(uraniumProcessingTech.icon)
+		uraniumProcessingTech.icon_size = 128 -- Base game tex size is now 256. Leave till icon is updated.
 	end
 end
 

--- a/src/prototypes/ores-retexture.lua
+++ b/src/prototypes/ores-retexture.lua
@@ -168,3 +168,7 @@ if mods["LiquifyRawMaterials"] then
 		end
 	end
 end
+
+data.raw["resource"]["iron-ore"].mining_visualisation_tint = mapColors["iron"]
+data.raw["resource"]["copper-ore"].mining_visualisation_tint = mapColors["copper"]
+data.raw["resource"]["uranium-ore"].mining_visualisation_tint = mapColors["uranium"]


### PR DESCRIPTION
I don't know why you do the game stuff on branches separate from master, so I'm not sure which branch to target, but here you go.
This gets it updated to Factorio 1.1.

Changes:
- uranium-ore uses layers for it's pictures. Essentially a child interstitial array.
- Set the uranium-processing icon_size to 128 so it loads. (Original is now 256.)